### PR TITLE
expose time concept used by ActiveRecord::Timestamp

### DIFF
--- a/activerecord/lib/active_record/timestamp.rb
+++ b/activerecord/lib/active_record/timestamp.rb
@@ -75,8 +75,14 @@ module ActiveRecord
         end
 
         def current_time_from_proper_timezone
-          default_timezone == :utc ? Time.now.utc : Time.now
+          ActiveRecord::Timestamp.current_time
         end
+    end
+
+    class << self
+      def current_time
+        ActiveRecord::Base.default_timezone == :utc ? Time.now.utc : Time.now
+      end
     end
 
   private
@@ -124,7 +130,7 @@ module ActiveRecord
     end
 
     def current_time_from_proper_timezone
-      self.class.send(:current_time_from_proper_timezone)
+      ActiveRecord::Timestamp.current_time
     end
 
     def max_updated_column_timestamp(timestamp_names = timestamp_attributes_for_update_in_model)

--- a/activerecord/test/cases/timestamp_test.rb
+++ b/activerecord/test/cases/timestamp_test.rb
@@ -455,6 +455,11 @@ class TimestampTest < ActiveRecord::TestCase
   ensure
     ActiveRecord::Base.connection.drop_table(:foos)
   end
+
+  def test_public_current_time_method_exists_and_is_used_for_timestamps
+    ActiveRecord::Timestamp.expects(:current_time).returns(Time.current.utc)
+    Car.create!
+  end
 end
 
 class TimestampsWithoutTransactionTest < ActiveRecord::TestCase


### PR DESCRIPTION
# needs to be changed into a PR on rails/rails when finished

- needs documentation
- test should not stub, use https://github.com/rails/rails/blob/master/activesupport/lib/active_support/testing/time_helpers.rb instead

### Summary

Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together.

### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](http://guides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails!
